### PR TITLE
feat: bootstrap inicial para unificar repos de OsoPanda1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python
+__pycache__/
+*.pyc
+.venv/
+
+# Build artifacts
+build/
+dist/
+
+# Monorepo integration workspace
+sources/
+cache/
+logs/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: bootstrap dry-run fmt check
+
+bootstrap:
+	python scripts/unify_repos.py --owner OsoPanda1 --target-root sources --manifest-out config/repos.json --max-repos 177
+
+dry-run:
+	python scripts/unify_repos.py --owner OsoPanda1 --manifest-out config/repos.json --max-repos 177 --dry-run
+
+fmt:
+	python -m compileall scripts src
+
+check: fmt
+	python scripts/unify_repos.py --owner OsoPanda1 --manifest-out config/repos.json --max-repos 5 --dry-run

--- a/README.md
+++ b/README.md
@@ -384,3 +384,23 @@ Sugerida (puede variar según el avance):
   <img src="https://komarev.com/ghpvc/?username=OsoPanda1&color=0EA5E9&label=Visitas&style=flat-square" />
 
 </div>
+
+---
+
+## 13. Bootstrap técnico del monorepo (nuevo)
+
+Para iniciar la unificación operativa de repositorios de `OsoPanda1` dentro de `tamv-digital-nexus`:
+
+```bash
+# Genera manifiesto (hasta 177 repos) sin clonar
+make dry-run
+
+# Clona/sincroniza repos en ./sources
+make bootstrap
+```
+
+Archivos clave agregados:
+
+- `scripts/unify_repos.py`: descubrimiento por API + sincronización git.
+- `config/repos.json`: manifiesto autogenerado de repositorios.
+- `docs/UNIFICACION.md`: plan de ejecución por fases.

--- a/docs/UNIFICACION.md
+++ b/docs/UNIFICACION.md
@@ -1,0 +1,32 @@
+# Plan de unificación TAMV Digital Nexus
+
+Este repositorio ahora incluye una base operativa para consolidar los repos de `OsoPanda1` en una sola plataforma.
+
+## Qué integra
+
+1. **Descubrimiento automático de repositorios** por API de GitHub.
+2. **Manifiesto trazable** en `config/repos.json` con metadata de cada repositorio.
+3. **Sincronización local** en `sources/<repo>` con `git clone` / `git fetch`.
+4. **Límite configurable** (`--max-repos`) para avanzar por fases hasta cubrir los 177 repos.
+
+## Flujo recomendado
+
+```bash
+# 1) Crear/actualizar el manifiesto de todos los repos
+make dry-run
+
+# 2) Ejecutar bootstrap completo (clona/sincroniza)
+make bootstrap
+
+# 3) Revisar repos integrados
+ls sources
+```
+
+## Notas
+
+- Para repos privados, exporta `GITHUB_TOKEN` con permisos de lectura.
+- Puedes repetir el proceso diariamente; el script hace `fetch + pull` si el repo ya existe.
+- Esta base permite extender una fase 2 con:
+  - indexado semántico,
+  - catálogo de servicios por repo,
+  - pipeline CI para pruebas agregadas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tamv-digital-nexus"
+version = "0.1.0"
+description = "Toolkit base para unificar repositorios de OsoPanda1 en un monorepo funcional"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [
+  {name = "OsoPanda1"}
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/scripts/unify_repos.py
+++ b/scripts/unify_repos.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Unifica múltiples repositorios de GitHub en un monorepo funcional.
+
+Uso rápido:
+  python scripts/unify_repos.py \
+      --owner OsoPanda1 \
+      --target-root sources \
+      --manifest-out config/repos.json \
+      --max-repos 177
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+GITHUB_API = "https://api.github.com"
+DEFAULT_BRANCHES = ("main", "master")
+
+
+@dataclass
+class Repo:
+    name: str
+    clone_url: str
+    default_branch: str
+    archived: bool
+    private: bool
+
+
+def github_get(path: str, token: str | None = None, query: dict[str, str | int] | None = None) -> tuple[dict | list, dict]:
+    q = f"?{urlencode(query)}" if query else ""
+    url = f"{GITHUB_API}{path}{q}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "tamv-digital-nexus-bootstrap",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    req = Request(url, headers=headers)
+    with urlopen(req, timeout=30) as response:
+        body = response.read().decode("utf-8")
+        payload = json.loads(body)
+        response_headers = dict(response.headers.items())
+    return payload, response_headers
+
+
+def list_repositories(owner: str, token: str | None = None, max_repos: int | None = None) -> list[Repo]:
+    page = 1
+    repos: list[Repo] = []
+
+    while True:
+        payload, _ = github_get(
+            f"/users/{owner}/repos",
+            token=token,
+            query={"per_page": 100, "page": page, "type": "owner", "sort": "updated"},
+        )
+
+        if not isinstance(payload, list) or not payload:
+            break
+
+        for item in payload:
+            repos.append(
+                Repo(
+                    name=item["name"],
+                    clone_url=item["clone_url"],
+                    default_branch=item.get("default_branch") or "main",
+                    archived=bool(item.get("archived", False)),
+                    private=bool(item.get("private", False)),
+                )
+            )
+            if max_repos and len(repos) >= max_repos:
+                return repos
+
+        page += 1
+
+    return repos
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> None:
+    print("$", " ".join(cmd))
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def clone_or_update(repo: Repo, target_root: Path) -> None:
+    destination = target_root / repo.name
+    if destination.exists() and (destination / ".git").exists():
+        run(["git", "-C", str(destination), "fetch", "--all", "--prune"])
+        branch = repo.default_branch if repo.default_branch else "main"
+        run(["git", "-C", str(destination), "checkout", branch])
+        run(["git", "-C", str(destination), "pull", "--ff-only", "origin", branch])
+        return
+
+    run(["git", "clone", repo.clone_url, str(destination)])
+
+
+def write_manifest(repos: Iterable[Repo], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "schema": "tamv-digital-nexus/repo-manifest@v1",
+        "repositories": [
+            {
+                "name": repo.name,
+                "clone_url": repo.clone_url,
+                "default_branch": repo.default_branch,
+                "archived": repo.archived,
+                "private": repo.private,
+            }
+            for repo in repos
+        ],
+    }
+    output_path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Unifica repositorios de un perfil de GitHub en un workspace local")
+    parser.add_argument("--owner", required=True, help="Usuario/owner de GitHub")
+    parser.add_argument("--token-env", default="GITHUB_TOKEN", help="Nombre de variable de entorno con token de GitHub")
+    parser.add_argument("--target-root", default="sources", help="Directorio donde se clonan los repos")
+    parser.add_argument("--manifest-out", default="config/repos.json", help="Archivo de salida del manifiesto")
+    parser.add_argument("--max-repos", type=int, default=None, help="Máximo de repos a sincronizar")
+    parser.add_argument("--include-archived", action="store_true", help="Incluye repos archivados")
+    parser.add_argument("--dry-run", action="store_true", help="No clona, solo genera manifiesto")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.getenv(args.token_env)
+
+    try:
+        repos = list_repositories(args.owner, token=token, max_repos=args.max_repos)
+    except (HTTPError, URLError) as exc:
+        print(f"Error consultando GitHub API: {exc}", file=sys.stderr)
+        return 1
+
+    if not args.include_archived:
+        repos = [r for r in repos if not r.archived]
+
+    write_manifest(repos, Path(args.manifest_out))
+    print(f"Manifest generado en {args.manifest_out} con {len(repos)} repositorios")
+
+    if args.dry_run:
+        return 0
+
+    target_root = Path(args.target_root)
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    failures: list[tuple[str, str]] = []
+    for repo in repos:
+        try:
+            clone_or_update(repo, target_root)
+        except subprocess.CalledProcessError as exc:
+            failures.append((repo.name, str(exc)))
+
+    if failures:
+        print("Repos con error:", file=sys.stderr)
+        for name, reason in failures:
+            print(f"  - {name}: {reason}", file=sys.stderr)
+        return 2
+
+    print(f"Sincronización completada: {len(repos)} repos")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tamv_digital_nexus/__init__.py
+++ b/src/tamv_digital_nexus/__init__.py
@@ -1,0 +1,4 @@
+"""Núcleo inicial de TAMV Digital Nexus."""
+
+__all__ = ["VERSION"]
+VERSION = "0.1.0"


### PR DESCRIPTION
### Motivation
- Crear una base operativa que permita consolidar los ~177 repositorios del perfil `OsoPanda1` en un monorepo funcional y trazable. 
- Proveer herramientas automáticas para descubrir, manifestar y sincronizar repositorios locales antes de una fase de integración más avanzada. 
- Facilitar un flujo reproducible (dry-run / bootstrap) que soporte repos públicos y privados usando `GITHUB_TOKEN` cuando el entorno tenga acceso a la API de GitHub.

### Description
- Se añadió `scripts/unify_repos.py`, un script que consulta la API de GitHub, genera un manifiesto JSON y clona / sincroniza repos en `sources/` con opciones `--dry-run`, `--max-repos`, `--include-archived` y `--token-env`.
- Se añadieron soporte operativo y metadatos: `Makefile` con objetivos `dry-run`, `bootstrap`, `fmt` y `check`, `docs/UNIFICACION.md` con el plan de unificación y `README.md` actualizado con la sección de bootstrap técnico.
- Estructura de paquete base y limpieza: `pyproject.toml` y paquete inicial `src/tamv_digital_nexus/__init__.py`, además de `.gitignore` para evitar artefactos (incluye `sources/`, `cache/`, `logs/`).

### Testing
- Se ejecutó `python -m compileall scripts src` y la verificación de compilación de los módulos Python pasó correctamente. ✅
- Se ejecutó `make check` que incluye una llamada a la API de GitHub en modo `--dry-run`; la ejecución falló con `403 Forbidden` al consultar la API por limitación de red/proxy en este entorno, por lo que la generación del manifiesto remoto no pudo completarse. ⚠️
- El flujo local y las tareas de formato/compilación están listas; la sincronización real requiere acceso de red a la API de GitHub (o un `GITHUB_TOKEN` en un entorno con salida a GitHub).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1147428a08326b6fb59b96bd6e4f3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/osopanda1/osopanda1/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstrap inicial para unificar hasta ~177 repos de `OsoPanda1` en un monorepo. Incluye script de descubrimiento/sincronización, manifiesto JSON y tareas de `Makefile` para dry-run y clonación.

- **New Features**
  - `scripts/unify_repos.py`: lista repos por API, genera `config/repos.json` y clona/sincroniza en `sources/` (flags: `--dry-run`, `--max-repos`, `--include-archived`, `--token-env`).
  - `Makefile`: `dry-run`, `bootstrap`, `fmt`, `check`.
  - Base de paquete `tamv-digital-nexus` (`pyproject.toml`, `src/tamv_digital_nexus/__init__.py` con versión inicial).
  - `.gitignore`: ignora `sources/`, `cache/`, `logs/`.
  - Docs: `docs/UNIFICACION.md` y README con pasos de arranque.

- **Migration**
  - Requiere acceso a la API de GitHub; usa `GITHUB_TOKEN` para repos privados.
  - Pasos: `make dry-run` para generar el manifiesto, luego `make bootstrap` para clonar/sincronizar.

<sup>Written for commit 5a21fb306a614f76bc27fcbe8069e3703e1d2c06. Summary will update on new commits. <a href="https://cubic.dev/pr/OsoPanda1/OsoPanda1/pull/1?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

