### PR TITLE
feat: agregar esqueleto de tamv-agent en Rust (gossip HMAC, estado atómico)

### DIFF
--- a/docs/integraciones/tamv-agent/README.md
+++ b/docs/integraciones/tamv-agent/README.md
@@ -1,0 +1,34 @@
+# TAMV Agent (diseño unificado 1→206→1)
+
+Este repositorio ahora incluye un esqueleto funcional de `tamv-agent` en Rust para estandarizar la capa de gossip/estado distribuido en los 206 repos TAMV.
+
+## Qué quedó integrado
+
+- Binario único: `tamv-agent/` (Rust + Tokio + Serde + HMAC SHA-256).
+- Formato de configuración por nodo: `config.toml` (ver ejemplo).
+- Estado persistente local: `state.json` con escritura atómica (`tmp + rename`).
+- Bucle asíncrono base con tick de gossip y firma de mensajes `STATE_SYNC`.
+
+## Uso local
+
+```bash
+cd tamv-agent
+cp examples/config.toml config.toml
+cargo run
+```
+
+## Despliegue a 206 repos
+
+1. Publicar binario estático `tamv-agent`.
+2. En cada repo:
+   - copiar `tamv-agent`;
+   - generar `config.toml` con `id/next_id/prev_id`;
+   - crear supervisor (systemd, sidecar Docker o script CI/CD) para mantener el proceso vivo.
+3. Persistir `state.json` junto al binario o en volumen dedicado.
+
+## Siguientes pasos recomendados
+
+- Agregar transporte real BLE/Wi‑Fi mesh en módulo `transport`.
+- Implementar tipos de mensaje completos: `HELLO`, `CHAIN_STEP`, `CHAIN_REPORT`.
+- Añadir verificación anti-replay (ventana de nonces + timestamp skew).
+- Integrar selección adaptativa de peers por fiabilidad.

--- a/tamv-agent/Cargo.toml
+++ b/tamv-agent/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tamv-agent"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+base64 = "0.22"
+chrono = { version = "0.4", features = ["serde"] }
+hmac = "0.12"
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "signal", "net"] }
+toml = "0.8"

--- a/tamv-agent/examples/config.toml
+++ b/tamv-agent/examples/config.toml
@@ -1,0 +1,13 @@
+[node]
+id = 1
+next_id = 2
+prev_id = 206
+
+[mesh]
+interface = "wlan0"
+gossip_interval_ms = 1500
+secret_key = "tamv-shared-secret-change-me"
+
+[agent]
+retry_limit = 3
+chain_timeout_ms = 12000

--- a/tamv-agent/src/main.rs
+++ b/tamv-agent/src/main.rs
@@ -1,0 +1,116 @@
+use anyhow::{Context, Result};
+use chrono::Utc;
+use hmac::{Hmac, Mac};
+use rand::{seq::IteratorRandom, thread_rng};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::{collections::HashMap, fs, path::PathBuf};
+use tokio::time::{interval, Duration};
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Debug, Deserialize)]
+struct Config {
+    node: Node,
+    mesh: Mesh,
+    agent: Agent,
+}
+
+#[derive(Debug, Deserialize)]
+struct Node { id: u16, next_id: u16, prev_id: u16 }
+
+#[derive(Debug, Deserialize)]
+struct Mesh { interface: String, gossip_interval_ms: u64, secret_key: String }
+
+#[derive(Debug, Deserialize)]
+struct Agent { retry_limit: u8, chain_timeout_ms: u64 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct RegistryEntry {
+    status: String,
+    last_seen: Option<String>,
+    chain_seen: Option<String>,
+    break_meta: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct State {
+    local_id: u16,
+    current_round: Option<String>,
+    registry: HashMap<u16, RegistryEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct WireMessage<'a, T: Serialize> {
+    kind: &'a str,
+    from_id: u16,
+    timestamp: String,
+    nonce: u64,
+    payload: T,
+    signature: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cfg = load_config("config.toml")?;
+    let mut state = load_or_init_state("state.json", cfg.node.id)?;
+
+    println!("tamv-agent iniciado en nodo {} sobre {}", cfg.node.id, cfg.mesh.interface);
+
+    let mut ticker = interval(Duration::from_millis(cfg.mesh.gossip_interval_ms));
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => {
+                let partial = select_partial_registry(&state.registry, 8);
+                let msg = signed_message("STATE_SYNC", cfg.node.id, &partial, &cfg.mesh.secret_key)?;
+                println!("gossip -> next={} prev={} entries={} sig={}..", cfg.node.next_id, cfg.node.prev_id, partial.len(), &msg.signature[..8]);
+                state.current_round = Some(Utc::now().to_rfc3339());
+                persist_state_atomic("state.json", &state)?;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                println!("tamv-agent detenido");
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn load_config(path: &str) -> Result<Config> {
+    let raw = fs::read_to_string(path).with_context(|| format!("no se pudo leer {path}"))?;
+    Ok(toml::from_str(&raw).context("config.toml inválido")?)
+}
+
+fn load_or_init_state(path: &str, local_id: u16) -> Result<State> {
+    if PathBuf::from(path).exists() {
+        let raw = fs::read_to_string(path)?;
+        return Ok(serde_json::from_str(&raw)?);
+    }
+
+    let state = State { local_id, current_round: None, registry: HashMap::new() };
+    persist_state_atomic(path, &state)?;
+    Ok(state)
+}
+
+fn persist_state_atomic(path: &str, state: &State) -> Result<()> {
+    let temp = format!("{path}.tmp");
+    fs::write(&temp, serde_json::to_vec_pretty(state)?)?;
+    fs::rename(temp, path)?;
+    Ok(())
+}
+
+fn signed_message<T: Serialize>(kind: &str, from_id: u16, payload: &T, secret: &str) -> Result<WireMessage<'_, T>> {
+    let nonce = rand::random::<u64>();
+    let timestamp = Utc::now().to_rfc3339();
+    let body = serde_json::json!({"kind": kind, "from_id": from_id, "timestamp": timestamp, "nonce": nonce, "payload": payload});
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).context("secret_key inválida")?;
+    mac.update(serde_json::to_string(&body)?.as_bytes());
+    let signature = base64::encode(mac.finalize().into_bytes());
+
+    Ok(WireMessage { kind, from_id, timestamp: body["timestamp"].as_str().unwrap().to_string(), nonce, payload, signature })
+}
+
+fn select_partial_registry(registry: &HashMap<u16, RegistryEntry>, k: usize) -> HashMap<u16, RegistryEntry> {
+    let mut rng = thread_rng();
+    registry.iter().choose_multiple(&mut rng, k).into_iter().map(|(id, e)| (*id, e.clone())).collect()
+}


### PR DESCRIPTION
### Motivation
- Unificar la capa de gossip/estado distribuido en un único binario `tamv-agent` reutilizable en los 206 repositorios cambiando solo `config.toml`.
- Proveer una base segura para mensajes firmados con HMAC y un loop asíncrono sobre `tokio` que permita implementar gossip antientropía y la lógica de la cadena 1→206→1.
- Garantizar persistencia local robusta mediante escrituras atómicas para resistir cortes y reinicios.

### Description
- Se añadió el nuevo módulo `tamv-agent/` con `Cargo.toml`, `src/main.rs`, `examples/config.toml` y la documentación en `docs/integraciones/tamv-agent/README.md`.
- `src/main.rs` implementa carga de `config.toml`, creación/carga de `state.json`, selección parcial de peers, generación de mensajes `STATE_SYNC` serializados y firmados con HMAC-SHA256, y un loop asíncrono con `tokio::select!` y ticker de gossip.
- La persistencia de estado usa una operación atómica (`tmp` + `rename`) en `persist_state_atomic` para evitar corrupciones por cortes de energía.
- Se agregó un ejemplo de configuración por nodo en `examples/config.toml` (campos `id`, `next_id`, `prev_id`, `mesh.secret_key`, etc.) y una guía de despliegue local y para los 206 repos.

### Testing
- Se intentó ejecutar `cargo check` en `tamv-agent/`, pero la resolución de dependencias falló por restricciones de red al descargar crates desde `crates.io` (`CONNECT tunnel failed, response 403`).
- No hay otros tests automatizados ejecutados en este entorno; el chequeo de compilación remota no completó, por lo que no se pudieron validar binarios compilados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d8ecbdc48330b850cd3ca033d06e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Se agregó el esqueleto de `tamv-agent` en Rust para unificar gossip y estado distribuido en los 206 repos, con mensajes firmados por HMAC y persistencia atómica. Permite configurar por `config.toml` y correr un loop asíncrono de gossip sobre `tokio`.

- **New Features**
  - Nuevo módulo `tamv-agent/` con `Cargo.toml`, `src/main.rs`, ejemplo `config.toml` y guía en `docs/integraciones/tamv-agent/README.md`.
  - Carga de `config.toml` y creación/carga de `state.json`.
  - Generación de `STATE_SYNC` serializados y firmados con HMAC-SHA256.
  - Loop de gossip con `tokio::select!` y ticker configurable.
  - Escritura atómica de estado con `persist_state_atomic` (`tmp + rename`).

- **Migration**
  - Construir y distribuir el binario `tamv-agent` en cada repo.
  - Proveer `config.toml` por nodo (`id`, `next_id`, `prev_id`, `mesh.secret_key`, etc.).
  - Ejecutar bajo un supervisor (systemd, sidecar Docker, CI/CD) y persistir `state.json`.

<sup>Written for commit 3f7ded7dad3a7080424209be264af25dbc202d51. Summary will update on new commits. <a href="https://cubic.dev/pr/OsoPanda1/OsoPanda1/pull/6?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

