### PR TITLE
feat: agregar plan secuencial de integración para Linear

### DIFF
--- a/docs/integraciones/LINEAR_ONBOARDING.md
+++ b/docs/integraciones/LINEAR_ONBOARDING.md
@@ -1,0 +1,48 @@
+# Conexión y arranque con Linear (TAMV Digital Nexus)
+
+## 1) Preparar acceso a Linear
+
+1. En Linear, crea un **API Key personal** desde `Settings > API > Personal API keys`.
+2. Exporta la variable en tu terminal:
+
+```bash
+export LINEAR_API_KEY="<tu_token>"
+```
+
+3. (Opcional) Define IDs de team/proyecto para automatizar creación de issues.
+
+## 2) Construir plan de integración repo por repo
+
+Desde la raíz del repositorio:
+
+```bash
+python -m tamv_digital_nexus.cli linear-plan \
+  --inventory config/repos_seed.json \
+  --out-json cache/linear_plan.json \
+  --out-md docs/integraciones/LINEAR_PLAN.md
+```
+
+Esto genera un plan secuencial para interconectar repositorios uno por uno con campos:
+- `depends_on`: issue/repositorio previo requerido.
+- `blocks`: siguiente repositorio a destrabar.
+
+## 3) Ejecutar la integración técnica local
+
+```bash
+python -m tamv_digital_nexus.cli integrate --inventory config/repos_seed.json
+```
+
+## 4) Ciclo recomendado en Linear
+
+Para cada repositorio en `LINEAR_PLAN.md`:
+
+1. Crear issue "[NEXUS] Integrar <repo>".
+2. Registrar dependencia contra `depends_on`.
+3. Ejecutar integración local y pruebas.
+4. Mover issue a `Done` y desbloquear `blocks`.
+
+## 5) Escalar a todos los repositorios
+
+1. Actualiza `config/repos_seed.json` con el listado completo de repositorios.
+2. Vuelve a ejecutar `linear-plan`.
+3. Crea issues en lote respetando el orden del plan.

--- a/docs/integraciones/LINEAR_PLAN.md
+++ b/docs/integraciones/LINEAR_PLAN.md
@@ -1,0 +1,20 @@
+# Plan de integración para Linear
+
+Estrategia: interconectar repositorios uno por uno con dependencias explícitas.
+
+| Orden | Repositorio | Depende de | Bloquea |
+| --- | --- | --- | --- |
+| 1 | OsoPanda1 | - | - |
+
+## Plantilla sugerida para issue en Linear
+
+**Título:** [NEXUS] Integrar OsoPanda1
+
+**Descripción:**
+Sincronizar este repositorio en el workspace federado y validar contratos de integración con el núcleo MD-X4.
+
+**Checklist:**
+- [ ] Clonar/sincronizar el repositorio
+- [ ] Ejecutar pruebas locales
+- [ ] Actualizar inventario de integración
+- [ ] Vincular issue siguiente en `blocks`

--- a/src/tamv_digital_nexus/cli.py
+++ b/src/tamv_digital_nexus/cli.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 
 from .inventory import load_inventory
+from .linear_plan import build_repo_sequence, export_linear_plan, render_markdown
 from .orchestrator import NexusIntegrator
 from .server import serve_index
 
@@ -18,6 +19,11 @@ def build_parser() -> argparse.ArgumentParser:
     integrate.add_argument("--workspace-root", default="sources")
     integrate.add_argument("--index-db", default="cache/nexus_index.db")
     integrate.add_argument("--index-json", default="cache/nexus_index.json")
+
+    linear = sub.add_parser("linear-plan", help="Genera plan secuencial para cargar issues en Linear")
+    linear.add_argument("--inventory", default="config/repos_seed.json")
+    linear.add_argument("--out-json", default="cache/linear_plan.json")
+    linear.add_argument("--out-md", default="docs/integraciones/LINEAR_PLAN.md")
 
     serve = sub.add_parser("serve", help="Sirve API local sobre el índice sqlite")
     serve.add_argument("--index-db", default="cache/nexus_index.db")
@@ -46,6 +52,15 @@ def main() -> int:
             for failure in report.failures:
                 print(f" - {failure}")
         return 0 if report.failed == 0 else 2
+
+    if args.command == "linear-plan":
+        artifacts = load_inventory(Path(args.inventory))
+        export_linear_plan(Path(args.out_json), artifacts)
+        sequence = build_repo_sequence(artifacts)
+        Path(args.out_md).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out_md).write_text(render_markdown(sequence), encoding="utf-8")
+        print(f"Plan Linear generado: {args.out_json} y {args.out_md}")
+        return 0
 
     if args.command == "serve":
         serve_index(Path(args.index_db), host=args.host, port=args.port)

--- a/src/tamv_digital_nexus/linear_plan.py
+++ b/src/tamv_digital_nexus/linear_plan.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from .models import RepoArtifact
+
+
+def build_repo_sequence(artifacts: list[RepoArtifact]) -> list[dict]:
+    """Construye una secuencia de integración repositorio a repositorio.
+
+    Se usa el orden del inventario como fuente de verdad para conectar
+    cada repositorio con su siguiente dependencia operativa.
+    """
+
+    sequence: list[dict] = []
+    for index, artifact in enumerate(artifacts):
+        depends_on = artifacts[index - 1].name if index > 0 else None
+        blocks = artifacts[index + 1].name if index < len(artifacts) - 1 else None
+        sequence.append(
+            {
+                "repo": artifact.name,
+                "depends_on": depends_on,
+                "blocks": blocks,
+                "default_branch": artifact.default_branch,
+                "source_url": artifact.source_url,
+                "tags": artifact.tags,
+                "linear_title": f"[NEXUS] Integrar {artifact.name}",
+                "linear_description": (
+                    "Sincronizar este repositorio en el workspace federado y "
+                    "validar contratos de integración con el núcleo MD-X4."
+                ),
+            }
+        )
+    return sequence
+
+
+def export_linear_plan(output_path: Path, artifacts: list[RepoArtifact]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    sequence = build_repo_sequence(artifacts)
+    payload = {
+        "schema": "tamv-digital-nexus/linear-plan@v1",
+        "integration_strategy": "sequential-one-by-one",
+        "repositories": sequence,
+    }
+    output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def render_markdown(sequence: list[dict]) -> str:
+    lines = [
+        "# Plan de integración para Linear",
+        "",
+        "Estrategia: interconectar repositorios uno por uno con dependencias explícitas.",
+        "",
+        "| Orden | Repositorio | Depende de | Bloquea |",
+        "| --- | --- | --- | --- |",
+    ]
+
+    for index, item in enumerate(sequence, start=1):
+        lines.append(
+            f"| {index} | {item['repo']} | {item['depends_on'] or '-'} | {item['blocks'] or '-'} |"
+        )
+
+    lines.extend(["", "## Plantilla sugerida para issue en Linear", ""])
+
+    if sequence:
+        sample = sequence[0]
+        lines.extend(
+            [
+                f"**Título:** {sample['linear_title']}",
+                "",
+                "**Descripción:**",
+                sample["linear_description"],
+                "",
+                "**Checklist:**",
+                "- [ ] Clonar/sincronizar el repositorio",
+                "- [ ] Ejecutar pruebas locales",
+                "- [ ] Actualizar inventario de integración",
+                "- [ ] Vincular issue siguiente en `blocks`",
+            ]
+        )
+
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
### Motivation

- Proveer una forma reproducible de preparar la carga de trabajo en Linear y convertir el inventario de repositorios en una secuencia operativa uno‑por‑uno.
- Facilitar la automatización de la creación de issues y dependencias en Linear para interconectar repositorios según un orden verificable.

### Description

- Se añadió el subcomando `linear-plan` a la CLI en `src/tamv_digital_nexus/cli.py` para generar y guardar el plan secuencial desde un inventario JSON.
- Se implementó `src/tamv_digital_nexus/linear_plan.py` con las funciones `build_repo_sequence`, `export_linear_plan` y `render_markdown` para construir la secuencia, exportarla a JSON y renderizar un `.md` para operaciones en Linear.
- Se añadieron guías y artefactos de salida en `docs/integraciones/LINEAR_ONBOARDING.md` y `docs/integraciones/LINEAR_PLAN.md` para onboarding y plantilla de issues en Linear.

### Testing

- Se ejecutó el flujo de generación de plan con `PYTHONPATH=src python -m tamv_digital_nexus.cli linear-plan --inventory config/repos_seed.json --out-json cache/linear_plan.json --out-md docs/integraciones/LINEAR_PLAN.md` y el comando generó los archivos esperados sin errores.
- Se ejecutaron los tests unitarios con `PYTHONPATH=src pytest -q` y todos los tests automatizados pasaron (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e2742dbc8330ac7c1bc7560abbc3)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agrega un plan secuencial de integración para Linear generado desde el inventario de repositorios, exportado a JSON y Markdown para crear issues y dependencias de forma reproducible. Permite interconectar repos uno a uno siguiendo un orden verificable.

- **New Features**
  - Subcomando `linear-plan` para generar el plan (JSON y Markdown) desde el inventario.
  - Secuencia basada en el orden del inventario con campos `depends_on` y `blocks` por repositorio.
  - Documentación de onboarding y plantilla de plan en `docs/integraciones/LINEAR_ONBOARDING.md` y `LINEAR_PLAN.md`.

<sup>Written for commit 792fd9aab049b2587cf40abea5d5f88c7ad504d3. Summary will update on new commits. <a href="https://cubic.dev/pr/OsoPanda1/OsoPanda1/pull/7?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

